### PR TITLE
Ensure `id` trait is passed through correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,14 +62,25 @@ Wishpond.prototype.loaded = function() {
 Wishpond.prototype.identify = function(identify) {
   if (!identify.userId()) return this.debug('user id required');
 
-  window.Wishpond.Tracker.identify(identify.userId(), identify.traits({
+  var traits = identify.traits({
     createdAt: 'created_at',
     updatedAt: 'updated_at',
     firstName: 'first_name',
     lastName: 'last_name',
     phoneNumber: 'phone_number',
     leadScore: 'lead_score'
-  }));
+  });
+
+  var originalTraits = identify.field('traits');
+
+  // Ensure an `id` trait is passed through correctly.
+  if ('id' in originalTraits) {
+    traits.id = originalTraits.id;
+  } else {
+    delete traits.id;
+  }
+
+  window.Wishpond.Tracker.identify(identify.userId(), traits);
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -78,7 +78,7 @@ describe('Wishpond', function() {
 
       it('should send an id', function() {
         analytics.identify('id');
-        analytics.called(window.Wishpond.Tracker.identify, 'id', { id: 'id' });
+        analytics.called(window.Wishpond.Tracker.identify, 'id', {});
       });
 
       it('should not send only traits', function() {
@@ -88,14 +88,13 @@ describe('Wishpond', function() {
 
       it('should send an id and traits', function() {
         analytics.identify('id', { trait: true, email: 'blackwidow@shield.gov' });
-        analytics.called(window.Wishpond.Tracker.identify, 'id', { id: 'id', trait: true, email: 'blackwidow@shield.gov' });
+        analytics.called(window.Wishpond.Tracker.identify, 'id', { trait: true, email: 'blackwidow@shield.gov' });
       });
 
       it('should alias createdAt to created_at', function() {
         var date = new Date();
         analytics.identify('id', { createdAt: date });
         analytics.called(window.Wishpond.Tracker.identify, 'id', {
-          id: 'id',
           created_at: date
         });
       });
@@ -104,7 +103,6 @@ describe('Wishpond', function() {
         var date = new Date();
         analytics.identify('id', { updatedAt: date });
         analytics.called(window.Wishpond.Tracker.identify, 'id', {
-          id: 'id',
           updated_at: date
         });
       });
@@ -113,7 +111,6 @@ describe('Wishpond', function() {
         var name = 'Anderson';
         analytics.identify('id', { firstName: name });
         analytics.called(window.Wishpond.Tracker.identify, 'id', {
-          id: 'id',
           first_name: name
         });
       });
@@ -122,7 +119,6 @@ describe('Wishpond', function() {
         var name = 'Saunders';
         analytics.identify('id', { lastName: name });
         analytics.called(window.Wishpond.Tracker.identify, 'id', {
-          id: 'id',
           last_name: name
         });
       });
@@ -131,7 +127,6 @@ describe('Wishpond', function() {
         var phone = '778 681 7804';
         analytics.identify('id', { phoneNumber: phone });
         analytics.called(window.Wishpond.Tracker.identify, 'id', {
-          id: 'id',
           phone_number: phone
         });
       });
@@ -140,7 +135,6 @@ describe('Wishpond', function() {
         var score = 5;
         analytics.identify('id', { leadScore: score });
         analytics.called(window.Wishpond.Tracker.identify, 'id', {
-          id: 'id',
           lead_score: score
         });
       });
@@ -149,8 +143,14 @@ describe('Wishpond', function() {
         var value = 'yes';
         analytics.identify('id', { notDefault: value });
         analytics.called(window.Wishpond.Tracker.identify, 'id', {
-          id: 'id',
           notDefault: value
+        });
+      });
+
+      it('should allow an `id` trait', function() {
+        analytics.identify('id', { id: '1234' });
+        analytics.called(window.Wishpond.Tracker.identify, 'id', {
+          id: '1234'
         });
       });
     });


### PR DESCRIPTION
When translating trait names in `identify.traits()`, `userId` is also translated to `id`, even though it is not specified to do so.

This commit ensures that if there is a trait called `id` it is passed correctly to the Wishpond tracker, otherwise it is removed to avoid tracking it as lead property.
